### PR TITLE
cancel right click event on battlekit signs

### DIFF
--- a/src/main/java/com/lol768/BattleKits/SignHandler.java
+++ b/src/main/java/com/lol768/BattleKits/SignHandler.java
@@ -38,7 +38,7 @@ public class SignHandler implements Listener {
 				Sign s = (Sign) e.getClickedBlock().getState();
 				String[] lines = s.getLines();
 				if (lines.length > 1 && lines[0].equals(ChatColor.DARK_RED + "[" + ChatColor.stripColor(plugin.global.getConfig().getString("brand")) + "]")) {
-					
+					e.setCancelled(true);
 					if (p.hasPermission("Battlekits.sign.use")) {
 						
 						if (!plugin.kits.getConfig().contains("kits." + lines[1])) {


### PR DESCRIPTION
fixes bug where the item in hand gets mixed with the new kit
